### PR TITLE
Removes PostalCodeInput from Navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For a full history of changes go to [base.store's CHANGELOG](https://github.com/
 
 ### Removed
 
+- `PostalCodeInput` from `Navbar`
+
 ### Fixed
 
 ### Security

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -2,7 +2,6 @@ import { List as UIList } from '@faststore/ui'
 import { graphql, Link as LinkGatsby, useStaticQuery } from 'gatsby'
 import React, { useRef, useState } from 'react'
 import CartToggle from 'src/components/cart/CartToggle'
-import PostalCodeInput from 'src/components/common/PostalCode'
 import SearchInput from 'src/components/common/SearchInput'
 import Icon from 'src/components/ui/Icon'
 import IconButton from 'src/components/ui/IconButton'
@@ -113,7 +112,6 @@ function Navbar() {
           </div>
         </section>
         <NavLinks />
-        <PostalCodeInput />
       </div>
 
       <SlideOver


### PR DESCRIPTION
## What's the purpose of this pull request?

Since the PostalCodeInput is yet not finished. We're removing it from the Navbar to avoid breaking the layout.

## How to test it?

Check the preview and see it the input is gone.

## Checklist

<em>You may erase this after checking them all ;)</em>

- [x] CHANGELOG entry added
