### PR TITLE
feat: Update Incentives properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- IncentivesHeader is now integrated with CMS
+- Add secondLineText to IncentivesHeader (#48)
+- IncentivesHeader is now integrated with CMS (#47)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add secondLineText property to IncentivesHeader (#48)
-- IncentivesHeader is now integrated with CMS (#47)
+- Add `secondLineText` property to `IncentivesHeader` (#48)
+- `IncentivesHeader` is now integrated with CMS (#47)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add secondLineText to IncentivesHeader (#48)
+- Add secondLineText property to IncentivesHeader (#48)
 - IncentivesHeader is now integrated with CMS (#47)
 
 ### Changed

--- a/cms/sections.json
+++ b/cms/sections.json
@@ -63,7 +63,7 @@
     "schema": {
       "title": "Incentives Header",
       "description": "Add Incentives to your shopper",
-      "required": ["title", "firstLineText", "icon"],
+      "required": ["firstLineText", "icon"],
       "type": "object",
       "properties": {
         "incentives": {
@@ -82,6 +82,10 @@
                 "type": "string",
                 "title": "First line text"
               },
+              "secondLineText": {
+                "type": "string",
+                "title": "Second line text"
+              },
               "icon": {
                 "type": "string",
                 "title": "Icon",
@@ -96,7 +100,7 @@
                   "Truck",
                   "Calendar",
                   "Gift",
-                  "StoreFront",
+                  "Storefront",
                   "ShieldCheck"
                 ]
               }

--- a/src/components/sections/Incentives/IncentivesHeader.tsx
+++ b/src/components/sections/Incentives/IncentivesHeader.tsx
@@ -3,8 +3,9 @@ import Section from '../Section'
 
 interface Incentive {
   icon: string
-  title: string
+  title?: string
   firstLineText: string
+  secondLineText?: string
 }
 
 interface Props {


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR will add the property `secondLineText` to `IncentivesHeader` section in `sections.json`.

## How does it work?

This PR work the same way as #47.

## How to test it?

Also refer to #47 on how to test this PR.

## References

Previous related PR #47 
The lack of the `secondLineText` was reported by @filipewl at this [PR](https://github.com/vtex-sites/base.store/pull/474#discussion_r847842914). Thanks a lot.

## Checklist

- [x] CHANGELOG entry added
